### PR TITLE
Feature/21 voeg optie toe om notificaties te pla

### DIFF
--- a/app/views/common/_aside.html.erb
+++ b/app/views/common/_aside.html.erb
@@ -2,6 +2,7 @@
   <section class="section  section--description">
     <%= image_tag "Hofakker-logo-vs-RGB.png", alt: "School de Hofakker logo" %>
     <p>Kleinschalig onderwijs dicht bij de natuur vanuit een antroposofisch mensbeeld</p>
+    <%= render partial: '/common/notifications' %>
     <nav class="nav  nav--social">
     <a href="https://twitter.com/hofakker">
       <svg width="16" height="16" class="icon  icon--twitter" role="img" alt="twitter"><title>twitter</title><use xlink:href="#twitter" fill="CurrentColor"></use></svg>

--- a/app/views/common/_footer.html.erb
+++ b/app/views/common/_footer.html.erb
@@ -3,7 +3,6 @@
     <div class="copyright  typeset">
       <small class="small">&copy; School de Hofakker 2020</small></br>
       <small class="small">&copy; Fotografie en film door <a href="https://saffloermohaupt.com" rel="nofollow">Saffloer Mohaupt</a></small></br>
-      <% veiligheid = @content.entries(content_type:'pagina', 'fields.slug[in]' => 'veiligheid').first %>
     </div>
   </div>
 </footer>

--- a/app/views/common/_notifications.html.erb
+++ b/app/views/common/_notifications.html.erb
@@ -1,0 +1,5 @@
+<% notificatie = @content.entries(content_type:'notificatie', order: '-sys.updatedAt').first %>
+<% if !notificatie.blank? %>
+  <h4><%= notificatie.title %></h4>
+  <%= @renderer.render(notificatie.content).html_safe %>
+<% end %>


### PR DESCRIPTION
Notificaties toegevoegd die in het zijpaneel de mogelijkheid geven om extra aandacht te trekken voor bijvoorbeeld een open dag.

Maak hiervoor nieuwe content aan van het type notifcatie:

![Screenshot from 2020-09-14 20-53-17](https://user-images.githubusercontent.com/1648248/93126657-ef7e1400-f6cc-11ea-8dff-1d94ab13173b.png)

Deze wordt dan in het zijpaneel getoond

![Screenshot from 2020-09-14 20-53-00](https://user-images.githubusercontent.com/1648248/93126655-eee57d80-f6cc-11ea-90e8-402f6472a367.png)

# Belangrijk!
Er zijn wel bepaalde regels:

- als er meerdere notificaties zijn in het cms wordt er op de website altijd maar 1 getoond om de vormgeving niet teveel te beinvloeden
- de notificatie die het meest recent bewerkt is is ook degene die op de website getoond wordt
- de notificatie moet altijd in de status `published` staan, anders wordt deze niet getoond, dit geld ook voor bijvoorbeeld images die je embed vanuit de media bibliotheek, die hebben ook hun eigen status die om getoond te worden op `published` moet staan
 
![Screenshot from 2020-09-14 20-54-11](https://user-images.githubusercontent.com/1648248/93126659-f016aa80-f6cc-11ea-96ad-a38287de96eb.png)

Als er geen notificaties in het cms zitten, of deze zijn niet gepubliceerd, dan wordt er verder ook niets getoond:

![Screenshot from 2020-09-14 20-55-18](https://user-images.githubusercontent.com/1648248/93126660-f0af4100-f6cc-11ea-9e4c-8e2df2e00923.png)
